### PR TITLE
Pea/75 seo description attachment post

### DIFF
--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -510,6 +510,9 @@ add_filter( 'page-links-to-post-types', __NAMESPACE__ . '\add_page_links_to_supp
 
 /**
  * Modify image used for seo meta
+ * Image size to use for image metadata
+ *
+ * @link https://kb.theseoframework.com/kb/filter-reference-for-the-seo-framework/#image-related
  *
  * @param array  $params
  * @param array  $args

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -521,3 +521,33 @@ function seo_framework_image_params( $params, $args, $context ) : array {
 	return $params;
 }
 add_filter( 'the_seo_framework_image_generation_params', __NAMESPACE__ . '\seo_framework_image_params', 10, 3 );
+
+/**
+ * Modify description for attachment posts
+ *
+ * @link https://kb.theseoframework.com/kb/filter-reference-for-the-seo-framework/#description-related
+ *
+ * @param string $description
+ * @param array  $args
+ * @return string $description
+ */
+function seo_framework_attachment_description( $description, $args ) : string {
+	if ( is_singular( 'attachment' ) ) {
+		$post_id     = ! empty( $args ) && isset( $args['id'] ) ? $args['id'] : the_seo_framework()->get_the_real_ID();
+		$description = \wp_kses_post( \get_post_field( 'post_content', $post_id ) );
+	}
+	return $description;
+}
+add_filter( 'the_seo_framework_generated_description', __NAMESPACE__ . '\seo_framework_attachment_description', 10, 2 );
+
+/**
+ * Support attachments
+ *
+ * @param array $post_types
+ * @return array $post_types
+ */
+function seo_framework_attachment_support( $post_types ) : array {
+	$post_types[] = 'attachment';
+	return $post_types;
+}
+add_filter( 'the_seo_framework_sitemap_supported_post_types', __NAMESPACE__ . '\seo_framework_attachment_support', 10 );


### PR DESCRIPTION
- [Add attachment support](https://github.com/madeofpeople/our-forests-theme/commit/ed4408ae2468bc78d806a5280c90077320d1a1e8) 
   - Render description metadata on attachment posts using description (`post_content`)